### PR TITLE
feat: run file as whole

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tags
 *coverage
 Pipfile*
 .hypothesis
+Session.vim

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # vim-ultest
 
-This plugin is in the early stages of development so there will likely be bugs!
-If you experience any problems please open an issue with as much detail as possible i.e. error messages, file type, test runner and minimal example.
-
 1. [Introduction](#introduction)
 2. [Features](#features)
 3. [Installation](#installation)
@@ -78,8 +75,7 @@ Due to the differences between Vim and NeoVim and their RPC libraries, it is ine
 I primarily use NeoVim so I will catch issues in it myself.
 Please file bug reports for Vim if you find them!
 
-I have not had the chance to extensively test (Neo)Vim versions, it is recommended to stay on the latest nightly version.
-If you have issues with missing features, please open an issue with your editor version.
+NeoVim >= 0.4.4 is supported for now, but once 0.5 is released support will be dropped due to added complexity from handling missing features.
 
 vim-ultest can be installed as usual with your favourite plugin manager.
 **Note:** NeoVim users must run `:UpdateRemotePlugins` after install if they don't use a plugin manager that already does.
@@ -148,6 +144,15 @@ augroup UltestRunner
     au BufWritePost * UltestNearest
 augroup END
 ```
+
+**Need user contributions**
+
+The `Ultest` command runs all tests in a file. For some test runners the plugin
+can parse the output of the runner to get results so that they can all be run
+as a single process. For other runners the tests all have to be run as
+inidividual processes, which can have a significant performance impact. Please
+check the wiki to see if your runner is supported.  If it is not please open an
+issue with example output and I can add support for it!
 
 ### Plug mappings
 

--- a/autoload/ultest/adapter.vim
+++ b/autoload/ultest/adapter.vim
@@ -3,13 +3,13 @@ function! ultest#adapter#get_runner(file)
   return test#determine_runner(a:file)
 endfunction
 
-function! ultest#adapter#build_cmd(test) abort
+function! ultest#adapter#build_cmd(test, scope) abort
   let a:test.file = fnamemodify(a:test.file, get(g:, "test#filename_modifier", ":."))
   call ultest#process#pre(a:test)
   let runner = ultest#adapter#get_runner(a:test.file)
   let executable = test#base#executable(runner)
 
-  let base_args = test#base#build_position(runner, "nearest", a:test)
+  let base_args = test#base#build_position(runner, a:scope, a:test)
   let args = test#base#options(runner, base_args)
   let args = test#base#build_args(runner, args, "ultest")
 

--- a/autoload/ultest/output.vim
+++ b/autoload/ultest/output.vim
@@ -32,6 +32,9 @@ endfunction
 function! ultest#output#attach(test) abort
   if type(a:test) != v:t_dict || empty(a:test) | return | endif
   let attach_res = ultest#handler#get_attach_script(a:test.id)
+  if type(attach_res) != v:t_list 
+    let attach_res = ultest#handler#get_attach_script(a:test.file)
+  endif
   if type(attach_res) != v:t_list | return | endif
   let [stdout_path, py_script] = attach_res
   doautocmd User UltestOutputOpen

--- a/autoload/ultest/signs.vim
+++ b/autoload/ultest/signs.vim
@@ -22,7 +22,7 @@ function! ultest#signs#process(result) abort
     call ultest#signs#unplace(test)
     if s:UseVirtual()
         let text_highlight = a:result.code ? "UltestFail" : "UltestPass"
-        let text = result.code ? g:ultest_fail_text : g:ultest_pass_text
+        let text = a:result.code ? g:ultest_fail_text : g:ultest_pass_text
         call s:PlaceVirtualText(test, text, text_highlight)
     else
         let test_icon = a:result.code ? "test_fail" : "test_pass"
@@ -35,7 +35,7 @@ function! s:UseVirtual() abort
 endfunction
 
 function! s:PlaceSign(test, test_icon) abort
-    call sign_place(0, a:test.name, a:test_icon, a:test.file, {"lnum": a:test.line, "priority": 1000})
+    call sign_place(0, a:test.id, a:test_icon, a:test.file, {"lnum": a:test.line, "priority": 1000})
     redraw
 endfunction
 
@@ -50,12 +50,12 @@ function! ultest#signs#unplace(test)
         let namespace = s:GetNamespace(a:test)
         call nvim_buf_clear_namespace(0, namespace, 0, -1)
     else
-        call sign_unplace(a:test["name"], {"buffer": a:test.file})
+        call sign_unplace(a:test.id, {"buffer": a:test.file})
       redraw
     endif
 endfunction
 
 function! s:GetNamespace(test)
-    let virtual_namespace = "ultest".substitute(a:test.name, " ", "_", "g")
+    let virtual_namespace = "ultest".substitute(a:test.id, " ", "_", "g")
     return nvim_create_namespace(virtual_namespace)
 endfunction

--- a/doc/ultest.txt
+++ b/doc/ultest.txt
@@ -135,8 +135,7 @@ dictionary with the following keys:
 a line of code
 
 'namepsace': A list of python-style regex patterns that can idenitfy test
-namespaces (e.g. Classes). This feature is currently unsupporte but will be in
-the future.
+namespaces (e.g. Classes).
 
 If you find a missing language that requires you to set this value,
 considering onpening an issue/PR to make it available to others.
@@ -166,7 +165,13 @@ as desired using the regular fold mappings.
 COMMANDS                                                     *ultest-commands*
 
 :Ultest                                                              *:Ultest*
-  Run all tests in the current file
+  Run all tests in the current file Some runners can be run as a single
+  command if the output can be parsed to gain results. Otherwise, each test is
+  run as a single command.
+
+  Running as a single command can significanly improve performance, so if your
+  runner is not yet supported please open an issue with sample output! Check
+  the repo wiki for an updated list of runners.
 
 :UltestNearest                                                *:UltestNearest*
   Run nearest test in the current file

--- a/lua/ultest.lua
+++ b/lua/ultest.lua
@@ -4,7 +4,7 @@ local builders = {}
 
 local function dap_run_test(test, build_config)
   local dap = require("dap")
-  local cmd = vim.fn["ultest#adapter#build_cmd"](test)
+  local cmd = vim.fn["ultest#adapter#build_cmd"](test, "nearest")
 
   local output_name = vim.fn["tempname"]()
 

--- a/plugin/ultest.vim
+++ b/plugin/ultest.vim
@@ -191,8 +191,7 @@ let g:ultest#processors = [
 " in a line of code
 "
 " 'namepsace': A list of python-style regex patterns that can idenitfy test
-" namespaces (e.g. Classes). This feature is currently unsupporte but will be
-" in the future.
+" namespaces (e.g. Classes).
 "
 " If you find a missing language that requires you to set this value,
 " considering onpening an issue/PR to make it available to others.
@@ -238,6 +237,12 @@ call sign_define("test_running", {"text":g:ultest_running_sign, "texthl": "Ultes
 
 ""
 " Run all tests in the current file
+" Some runners can be run as a single command if the output can be parsed to
+" gain results. Otherwise, each test is run as a single command.
+"
+" Running as a single command can significanly improve performance, so if your
+" runner is not yet supported please open an issue with sample output! Check
+" the repo wiki for an updated list of runners.
 command! Ultest call ultest#run_file({"pre_run": g:ultest_pre_run})
 
 ""

--- a/rplugin/python3/ultest/handler/parser/__init__.py
+++ b/rplugin/python3/ultest/handler/parser/__init__.py
@@ -1,0 +1,72 @@
+import re
+from dataclasses import dataclass
+from typing import Iterator, List, Optional
+
+from ...logging import UltestLogger
+
+
+@dataclass(frozen=True)
+class ParseResult:
+    name: str
+    namespaces: List[str]
+
+
+@dataclass
+class OutputPatterns:
+    failed_test: str
+    namespace_separator: Optional[str] = None
+    ansi: bool = False
+
+
+_BASE_PATTERNS = {
+    "python#pytest": OutputPatterns(
+        failed_test=r"^FAILED .+?::(?P<namespaces>.+::)?(?P<name>.*?) ",
+        namespace_separator="::",
+    ),
+    "python#pyunit": OutputPatterns(
+        failed_test=r"^FAIL: (?P<name>.*) \(.*?(?P<namespaces>\..+)\)",
+        namespace_separator=r"\.",
+    ),
+    "go#gotest": OutputPatterns(failed_test=r"^--- FAIL: (?P<name>.+?) "),
+    "javascript#jest": OutputPatterns(
+        failed_test=r"^\s*● (?P<namespaces>.* › )?(?P<name>.*)$",
+        ansi=True,
+        namespace_separator=" › ",
+    ),
+}
+
+# https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
+_ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
+class OutputParser:
+    def __init__(self, logger: UltestLogger) -> None:
+        self._log = logger
+        self._patterns = _BASE_PATTERNS
+
+    def can_parse(self, runner: str) -> bool:
+        return runner in self._patterns
+
+    def parse_failed(self, runner: str, output: List[str]) -> Iterator[ParseResult]:
+        pattern = self._patterns[runner]
+        fail_pattern = re.compile(pattern.failed_test)
+        for line in output:
+            match = fail_pattern.match(
+                _ANSI_ESCAPE.sub("", line) if pattern.ansi else line
+            )
+            if match:
+                self._log.finfo(
+                    "Found failed test in output {match['name']} in namespaces {match['namespaces']} of runner {runner}"
+                )
+                namespaces = (
+                    [
+                        namespace
+                        for namespace in re.split(
+                            pattern.namespace_separator, match["namespaces"]
+                        )
+                        if namespace
+                    ]
+                    if pattern.namespace_separator and match["namespaces"]
+                    else []
+                )
+                yield ParseResult(name=match["name"], namespaces=namespaces)

--- a/rplugin/python3/ultest/models/__init__.py
+++ b/rplugin/python3/ultest/models/__init__.py
@@ -1,2 +1,3 @@
+from .namespace import Namespace
 from .result import Result
 from .test import Test

--- a/rplugin/python3/ultest/models/namespace.py
+++ b/rplugin/python3/ultest/models/namespace.py
@@ -1,18 +1,15 @@
 import json
-from dataclasses import asdict, dataclass, field
-from typing import List
+from dataclasses import asdict, dataclass
 
 
 @dataclass(repr=False)
-class Test:
+class Namespace:
 
     id: str
     name: str
     file: str
     line: int
     col: int
-    running: int
-    namespaces: List[str] = field(default_factory=list)
 
     def __str__(self):
         return self.__repr__()

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -1,0 +1,16 @@
+import os
+from typing import List
+
+
+def get_output(runner: str) -> List[str]:
+    dirname = os.path.dirname(__file__)
+    filename = os.path.join(dirname, "test_outputs", runner)
+    with open(filename) as output:
+        return output.readlines()
+
+
+def get_test_file(name: str) -> str:
+    dirname = os.path.dirname(__file__)
+    filename = os.path.join(dirname, "test_files", name)
+    with open(filename) as output:
+        return output.read()

--- a/tests/mocks/test_files/python
+++ b/tests/mocks/test_files/python
@@ -1,10 +1,12 @@
-mock_python_file = """
 from time import sleep
 
 def test_a30():
     assert 2 == 3
 
+class TestMock:
+    def test_a10():
+        assert 3 == 3
+
 def test_a43():
     sleep(1)
     assert 3 == 3
-"""

--- a/tests/mocks/test_outputs/gotest
+++ b/tests/mocks/test_outputs/gotest
@@ -1,0 +1,7 @@
+--- FAIL: TestA (0.00s)
+    main_test.go:10: 2 != 2
+--- FAIL: TestB (0.00s)
+    main_test.go:19: 2 != 2
+FAIL
+FAIL	command-line-arguments	0.002s
+FAIL

--- a/tests/mocks/test_outputs/jest
+++ b/tests/mocks/test_outputs/jest
@@ -1,0 +1,47 @@
+[0m[7m[1m[31m FAIL [39m[22m[27m[0m [2mspec/[22m[1multest a.test.ts[22m
+  [31m✕[39m [2mit shouldn't pass again[22m
+  [32m✓[39m [2mit shouldn pass (1 ms)[22m
+  First namespace
+    Another namespace
+      [31m✕[39m [2mit shouldn't pass (3 ms)[22m
+
+[1m[31m  [1m● [22m[1mFirst namespace › Another namespace › it shouldn't pass[39m[22m
+
+    [2mexpect([22m[31mreceived[39m[2m).[22mtoBeFalsy[2m()[22m
+
+    Received: [31mtrue[39m
+[2m[22m
+[2m    [0m [90m 2 | [39m  describe([32m"Another namespace"[39m[33m,[39m () [33m=>[39m {[0m[22m
+[2m    [0m [90m 3 | [39m    test([32m"it shouldn't pass"[39m[33m,[39m () [33m=>[39m {[0m[22m
+[2m    [0m[31m[1m>[22m[2m[39m[90m 4 | [39m      expect([36mtrue[39m)[33m.[39mtoBeFalsy()[0m[22m
+[2m    [0m [90m   | [39m                   [31m[1m^[22m[2m[39m[0m[22m
+[2m    [0m [90m 5 | [39m    })[33m;[39m[0m[22m
+[2m    [0m [90m 6 | [39m  })[33m;[39m[0m[22m
+[2m    [0m [90m 7 | [39m})[33m;[39m[0m[22m
+[2m[22m
+[2m      [2mat Object.<anonymous> ([22m[2m[0m[36mspec/ultest a.test.ts[39m[0m[2m:4:20)[22m[2m[22m
+[2m      [2mat processTicksAndRejections ([22m[2mnode:internal/process/task_queues[2m:94:5)[22m[2m[22m
+
+[1m[31m  [1m● [22m[1mit shouldn't pass again[39m[22m
+
+    [2mexpect([22m[31mreceived[39m[2m).[22mtoBeFalsy[2m()[22m
+
+    Received: [31mtrue[39m
+[2m[22m
+[2m    [0m [90m  7 | [39m})[33m;[39m[0m[22m
+[2m    [0m [90m  8 | [39mtest([32m"it shouldn't pass again"[39m[33m,[39m () [33m=>[39m {[0m[22m
+[2m    [0m[31m[1m>[22m[2m[39m[90m  9 | [39m  expect([36mtrue[39m)[33m.[39mtoBeFalsy()[0m[22m
+[2m    [0m [90m    | [39m               [31m[1m^[22m[2m[39m[0m[22m
+[2m    [0m [90m 10 | [39m})[33m;[39m[0m[22m
+[2m    [0m [90m 11 | [39mtest([32m"it shouldn pass"[39m[33m,[39m () [33m=>[39m {[0m[22m
+[2m    [0m [90m 12 | [39m  expect([36mfalse[39m)[33m.[39mtoBeFalsy()[0m[22m
+[2m[22m
+[2m      [2mat Object.<anonymous> ([22m[2m[0m[36mspec/ultest a.test.ts[39m[0m[2m:9:16)[22m[2m[22m
+[2m      [2mat processTicksAndRejections ([22m[2mnode:internal/process/task_queues[2m:94:5)[22m[2m[22m
+
+[1mTest Suites: [22m[1m[31m1 failed[39m[22m, 1 total
+[1mTests:       [22m[1m[31m2 failed[39m[22m, [1m[32m1 passed[39m[22m, 3 total
+[1mSnapshots:   [22m0 total
+[1mTime:[22m        1.658 s
+[2mRan all test suites[22m[2m matching [22m/spec\/ultest a.test.ts/i[2m.[22m
+

--- a/tests/mocks/test_outputs/pytest
+++ b/tests/mocks/test_outputs/pytest
@@ -1,0 +1,33 @@
+[1m============================= test session starts ==============================[0m
+platform linux -- Python 3.9.2, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
+rootdir: /home/ronan/tests
+plugins: cov-2.11.1
+collected 3 items
+
+test_a.py [31mF[0m[32m.[0m[31mE[0m[31m                                                            [100%][0m
+
+==================================== ERRORS ====================================
+[31m[1m___________________________ ERROR at setup of test_a ___________________________[0m
+file /home/ronan/tests/test_a.py, line 17
+  def test_a(self):
+[31mE       fixture 'self' not found[0m
+[31m>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, cov, doctest_namespace, monkeypatch, no_cover, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory[0m
+[31m>       use 'pytest --fixtures [testpath]' for help on them.[0m
+
+/home/ronan/tests/test_a.py:17
+=================================== FAILURES ===================================
+[31m[1m______________________________ TestMyClass.test_d ______________________________[0m
+
+self = <test_a.TestMyClass testMethod=test_d>
+
+    [94mdef[39;49;00m [92mtest_d[39;49;00m([96mself[39;49;00m): [90m# type: ignore[39;49;00m
+        [94mclass[39;49;00m [04m[92mMyClass[39;49;00m:
+            ...
+>       [94massert[39;49;00m [94m33[39;49;00m == [94m3[39;49;00m
+[1m[31mE       AssertionError: assert 33 == 3[0m
+
+[1m[31mtest_a.py[0m:7: AssertionError
+=========================== short test summary info ============================
+FAILED test_a.py::TestMyClass::test_d - AssertionError: assert 33 == 3
+ERROR test_a.py::test_a
+[31m===================== [31m[1m1 failed[0m, [32m1 passed[0m, [31m[1m1 error[0m[31m in 0.07s[0m[31m =====================[0m

--- a/tests/mocks/test_outputs/pyunit
+++ b/tests/mocks/test_outputs/pyunit
@@ -1,0 +1,13 @@
+F.
+======================================================================
+FAIL: test_d (test_a.TestMyClass)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "/home/ronan/tests/test_a.py", line 9, in test_d
+    assert 33 == 3
+AssertionError
+
+----------------------------------------------------------------------
+Ran 2 tests in 0.001s
+
+FAILED (failures=1)

--- a/tests/unit/handler/parser/test_init.py
+++ b/tests/unit/handler/parser/test_init.py
@@ -1,0 +1,49 @@
+from unittest import TestCase
+from unittest.mock import Mock
+
+from rplugin.python3.ultest.handler.parser import OutputParser, ParseResult
+from tests.mocks import get_output
+
+
+class TestOutputParser(TestCase):
+    def setUp(self) -> None:
+        self.parser = OutputParser(logger=Mock())
+
+    def test_parse_pytest(self):
+        output = get_output("pytest")
+        failed = list(self.parser.parse_failed("python#pytest", output))
+        self.assertEqual(
+            failed, [ParseResult(name="test_d", namespaces=["TestMyClass"])]
+        )
+
+    def test_parse_pyunit(self):
+        output = get_output("pyunit")
+        failed = list(self.parser.parse_failed("python#pyunit", output))
+        self.assertEqual(
+            failed, [ParseResult(name="test_d", namespaces=["TestMyClass"])]
+        )
+
+    def test_parse_gotest(self):
+        output = get_output("gotest")
+        failed = list(self.parser.parse_failed("go#gotest", output))
+        self.assertEqual(
+            failed,
+            [
+                ParseResult(name="TestA", namespaces=[]),
+                ParseResult(name="TestB", namespaces=[]),
+            ],
+        )
+
+    def test_parse_jest(self):
+        output = get_output("jest")
+        failed = list(self.parser.parse_failed("javascript#jest", output))
+        self.assertEqual(
+            failed,
+            [
+                ParseResult(
+                    name="it shouldn't pass",
+                    namespaces=["First namespace", "Another namespace"],
+                ),
+                ParseResult(name="it shouldn't pass again", namespaces=[]),
+            ],
+        )

--- a/tests/unit/handler/test_finder.py
+++ b/tests/unit/handler/test_finder.py
@@ -8,7 +8,7 @@ from hypothesis.strategies import builds, integers, lists
 
 from rplugin.python3.ultest.handler.finder import TestFinder
 from rplugin.python3.ultest.models.test import Test
-from tests.mocks.test_files import mock_python_file
+from tests.mocks import get_test_file
 
 
 def sorted_tests(
@@ -62,8 +62,7 @@ def test_get_nearest_from_non_strict_no_match(tests: List[Test]):
     assert result is None
 
 
-@patch("builtins.open", mock_open(read_data=mock_python_file))
-@patch("builtins.hash", lambda o: len(".".join(o)))
+@patch("builtins.open", mock_open(read_data=get_test_file("python")))
 @patch("os.path.isfile", lambda _: True)
 @pytest.mark.asyncio
 async def test_find_python_tests():
@@ -72,25 +71,36 @@ async def test_find_python_tests():
         "namespace": [r"\v^\s*class (\w+)"],
     }
 
+    tests, namespaces = await finder.find_all("", patterns)
+
     expected = [
         Test(
-            id="test_a3025",
+            id=tests[0].id,
             name="test_a30",
             file="",
-            line=4,
+            line=3,
             col=1,
             running=0,
+            namespaces=[],
         ),
         Test(
-            id="test_a4341",
-            name="test_a43",
+            id=tests[1].id,
+            name="test_a10",
             file="",
             line=7,
             col=1,
             running=0,
+            namespaces=["TestMock"],
+        ),
+        Test(
+            id=tests[2].id,
+            name="test_a43",
+            file="",
+            line=10,
+            col=1,
+            running=0,
+            namespaces=[],
         ),
     ]
 
-    result = await finder.find_all("", patterns)
-
-    assert result == expected
+    assert tests == expected


### PR DESCRIPTION
Currently the plugin runs all tests individually, spawning a separate
process for each one. This change allows a file to be run as whole, as
long as the output parser knows how to parse the runner's output.

As a consequence of this, we're also now parsing the namespaces in which
a test is defined, similarly to vim-test where it uses the indents.
Currently they are only used in parsing output, but they will be able to
be run as groups as well soon enough.