### PR TITLE
Support Elixir controller tests

### DIFF
--- a/plugin/ultest.vim
+++ b/plugin/ultest.vim
@@ -244,7 +244,7 @@ let g:ultest_custom_patterns = get(g:, "ultest_custom_patterns", {})
 
 let g:ultest_patterns = extend({
       \ "elixir#exunit": {
-        \ 'test': ["^\\s*test\\s+['\"](.+)['\"](,\\s%{.+})*\\s+do"],
+        \ 'test': ["^\\s*test\\s+['\"](.+)['\"](,\\s+%{.+})*\\s+do"],
       \}
     \ }, g:ultest_custom_patterns)
 

--- a/plugin/ultest.vim
+++ b/plugin/ultest.vim
@@ -244,7 +244,7 @@ let g:ultest_custom_patterns = get(g:, "ultest_custom_patterns", {})
 
 let g:ultest_patterns = extend({
       \ "elixir#exunit": {
-        \ 'test': ["^\\s*test\\s+['\"](.+)['\"]\\s+do"],
+        \ 'test': ["^\\s*test\\s+['\"](.+)['\"](,\\s%{.+})*\\s+do"],
       \}
     \ }, g:ultest_custom_patterns)
 


### PR DESCRIPTION
if we consider this basic controller test example: 
```elixir
describe "index" do
  test "lists all posts", %{conn: conn} do
    conn = get(conn, Routes.post_path(conn, :index))
    assert html_response(conn, 200) =~ "List all posts"
  end
end
```

we will see that the pattern used for identifying elixir tests doesn't work as the regex doesn't account for the `,%{conn: conn}` part.

The change in this MR should improve the experience of this plugin with Elixir.