### PR TITLE
Clarify the sentence about dropping Neovim 0.4.4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Due to the differences between Vim and NeoVim and their RPC libraries, it is ine
 I primarily use NeoVim so I will catch issues in it myself.
 Please file bug reports for Vim if you find them!
 
-NeoVim >= 0.4.4 is supported for now, but once 0.5 is released support will be dropped due to added complexity from handling missing features.
+NeoVim >= 0.4.4 is supported for now, but once 0.5 is released support for earlier versions will be dropped due to added complexity from handling missing features.
 
 vim-ultest can be installed as usual with your favourite plugin manager.
 **Note:** NeoVim users must run `:UpdateRemotePlugins` after install if they don't use a plugin manager that already does.


### PR DESCRIPTION
This might seem like pointless nitpicking, but someone on Matrix actually read this sentence in the README to mean "Once Neovim 0.5 is released, support for all versions >0.4.4 (i.e., including 0.5) will be removed". This doesn't seem to me to be a meaningful interpretation, but it's true that the sentence is ambiguous if you read it literally. Hence this patch.