### PR TITLE
fix: Fixing the custom test strategy override from vim-test

### DIFF
--- a/plugin/ultest.vim
+++ b/plugin/ultest.vim
@@ -4,7 +4,7 @@ endif
 let g:ultest_loaded = 1
 
 let s:strategy = "ultest"
-let g:test#custom_strategies = get(g:, "test#custom#strategies", {})
+let g:test#custom_strategies = get(g:, "test#custom_strategies", {})
 let g:test#custom_strategies[s:strategy] = function('ultest#handler#strategy')
 let g:ultest_buffers = []
 


### PR DESCRIPTION
- Using the correct variable name (from vim-test) so that
  any original custom strategies are preserved and extended by ultest

**Rationale**: I have been using custom strategies in vim-test, and when I installed ultest (which is fantastic by the way!) I noticed my custom strategies were no longer available. I realised this is because the custom strategies variable that is retrieved in the ultest code (presumably with the intention of adding on the ultest#handler#strategy) is using a different variable name to the one use by vim-test (see https://github.com/vim-test/vim-test#custom-strategies), so it blows away any custom strategies that had been set using this original vim-test global variable.

I worked around this by updating my config to set test#custom#strategies instead of test#custom_strategies, but believe it should be fixed so that the variable names are consistent between the two plugins.

Of course, anyone else who happened to use this workaround as I did, will then have to revert back if this fix goes in.