### PR TITLE
Fix error when call UltestSummaryOpen

### DIFF
--- a/autoload/ultest/summary.vim
+++ b/autoload/ultest/summary.vim
@@ -33,9 +33,12 @@ function! ultest#summary#jumpto() abort
   call ultest#util#goToBuffer(s:buffer_name)
 endfunction
 
-function! ultest#summary#open() abort
+function! ultest#summary#open(jump = v:false) abort
   if !s:IsOpen() 
     call s:OpenNewWindow()
+    if a:jump
+      call ultest#summary#jumpto()
+   end
   endif
 endfunction
 


### PR DESCRIPTION
```
Error detected while processing function dein#autoload#_on_cmd:
line   13:
E118: Too many arguments for function: ultest#summary#open
```

This problem occurs from https://github.com/rcarriga/vim-ultest/issues/67

## current code
https://github.com/rcarriga/vim-ultest/blob/dfea06dc0e8da24338eef3414259055f360449cb/plugin/ultest.vim#L342

https://github.com/rcarriga/vim-ultest/blob/dfea06dc0e8da24338eef3414259055f360449cb/autoload/ultest/summary.vim#L36-L40
