### PR TITLE
fix: Allowed using loop parameter if using python <3.10

### DIFF
--- a/rplugin/python3/ultest/vim_client/jobs/__init__.py
+++ b/rplugin/python3/ultest/vim_client/jobs/__init__.py
@@ -35,7 +35,10 @@ class JobManager:
 
     def run(self, cor: Coroutine, job_group: str):
         job_id = str(uuid4())
-        cancel_event = Event(loop=self._loop) if sys.version_info < (3, 8) else Event()
+        # loop parameter has been deprecated since version 3.8
+        # and will be removed in version 3.10 but loop parameters
+        # still required for python <3.10
+        cancel_event = Event(loop=self._loop) if sys.version_info < (3, 10) else Event()
         wrapped_cor = self._handle_coroutine(
             cor, job_group=job_group, job_id=job_id, cancel_event=cancel_event
         )


### PR DESCRIPTION
Related to PR #76 but the recent release seems to break when using python 3.9. The deprecated check should be expanded to python <3.10. 


Having some issues with the indenting on my local matching what is on github but it runs fine for me. 