### PR TITLE
fix: better :cd handling

### DIFF
--- a/rplugin/python3/ultest/handler/runner/__init__.py
+++ b/rplugin/python3/ultest/handler/runner/__init__.py
@@ -121,6 +121,13 @@ class PositionRunner:
     def get_attach_script(self, process_id: str):
         return self._processes.create_attach_script(process_id)
 
+    def _get_cwd(self) -> Optional[str]:
+        return (
+            self._vim.sync_call("get", "g:", "test#project_root")
+            or self._vim.sync_call("getcwd")
+            or None
+        )
+
     def _run_separately(
         self,
         tree: Tree[Position],
@@ -132,7 +139,7 @@ class PositionRunner:
         Run a collection of tests. Each will be done in
         a separate thread.
         """
-        root = self._vim.sync_call("get", "g:", "test#project_root") or None
+        root = self._get_cwd()
         tests = []
         for pos in tree:
             if isinstance(pos, Test):
@@ -166,7 +173,7 @@ class PositionRunner:
         runner = self._vim.sync_call("ultest#adapter#get_runner", file_name)
         scope = "file" if isinstance(tree.data, File) else "nearest"
         cmd = self._vim.sync_call("ultest#adapter#build_cmd", tree[0], scope)
-        root = self._vim.sync_call("get", "g:", "test#project_root") or None
+        root = self._get_cwd()
 
         for pos in tree:
             self._register_started(pos, on_start)

--- a/rplugin/python3/ultest/handler/tracker.py
+++ b/rplugin/python3/ultest/handler/tracker.py
@@ -26,6 +26,8 @@ class PositionTracker:
         :param file_name: Name of file to clear results from.
         """
 
+        file_name = self._vim.sync_call("fnamemodify", file_name, ":p")
+
         if not os.path.isfile(file_name):
             return
 
@@ -88,9 +90,11 @@ class PositionTracker:
             callback()
 
     def file_positions(self, file: str) -> Optional[Tree[Position]]:
-        return self._stored_positions.get(file)
+        absolute_path = self._vim.sync_call("fnamemodify", file, ":p")
+        return self._stored_positions.get(absolute_path)
 
     def _init_test_file(self, file: str):
+        logger.info(f"Initialising test file {file}")
         self._vim.call("setbufvar", file, "ultest_results", {})
         self._vim.call("setbufvar", file, "ultest_tests", {})
         self._vim.call("setbufvar", file, "ultest_sorted_tests", [])


### PR DESCRIPTION
Introduces a few changes to better handle the directory changing using
the :cd command.
- Use absolute file paths to track files rather than relative.
- Deleting old summary window as it doesn't get opened with edit command
  after cd despite being `nofile` type
- Updating summary window on DirChanged
- Using relative file paths in summary window