### PR TITLE
Feature/phpunit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 
 [tools.black]
-line-length=120
+line-length = 120
 
 [tool.isort]
 profile = "black"
@@ -8,8 +8,8 @@ multi_line_output = 3
 
 [tool.pytest.ini_options]
 filterwarnings = [
-    "error",
-    "ignore::pytest.PytestCollectionWarning",
-    "ignore:::pynvim[.*]"
+  "error",
+  "ignore::pytest.PytestCollectionWarning",
+  "ignore:::pynvim[.*]",
 ]
-
+asyncio_mode = "auto"

--- a/rplugin/python3/ultest/handler/parsers/output.py
+++ b/rplugin/python3/ultest/handler/parsers/output.py
@@ -42,7 +42,7 @@ _BASE_PATTERNS = {
     "elixir#exunit": OutputPatterns(failed_test=r"\s*\d\) test (?P<name>.*) \(.*\)$"),
     "php#phpunit": OutputPatterns(
         failed_test=r"\s*\d\)(?P<namespace>.*)::(?P<name>.*)",
-    )
+    ),
 }
 
 # https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python

--- a/rplugin/python3/ultest/handler/parsers/output.py
+++ b/rplugin/python3/ultest/handler/parsers/output.py
@@ -41,7 +41,8 @@ _BASE_PATTERNS = {
     ),
     "elixir#exunit": OutputPatterns(failed_test=r"\s*\d\) test (?P<name>.*) \(.*\)$"),
     "php#phpunit": OutputPatterns(
-        failed_test=r"\s*\d\)(?P<namespace>.*)::(?P<name>.*)",
+        failed_test=r"\s*\d\) (?P<namespaces>.*)::(?P<name>.*)",
+        namespace_separator=r"\\",
     ),
 }
 

--- a/rplugin/python3/ultest/handler/parsers/output.py
+++ b/rplugin/python3/ultest/handler/parsers/output.py
@@ -40,6 +40,9 @@ _BASE_PATTERNS = {
         namespace_separator=" › ",
     ),
     "elixir#exunit": OutputPatterns(failed_test=r"\s*\d\) test (?P<name>.*) \(.*\)$"),
+    "php#phpunit": OutputPatterns(
+        failed_test=r"\s*\d\)(?P<namespace>.*)::(?P<name>.*)",
+    )
 }
 
 # https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python

--- a/tests/mocks/test_outputs/phpunit
+++ b/tests/mocks/test_outputs/phpunit
@@ -1,0 +1,18 @@
+
+PHPUnit 9.5.8 by Sebastian Bergmann and contributors.
+
+F.                                                                  2 / 2 (100%)
+
+Time: 00:03.103, Memory: 40.50 MB
+
+There was 1 failure:
+
+1) Tests\FakeTest::test_fake
+Failed asserting that 0.0 matches expected 1.0.
+
+/Users/bwubs/Projects/foo/tests/FakeTest:18
+
+FAILURES!
+Tests: 2, Assertions: 2, Failures: 1.
+
+[Process exited 1]

--- a/tests/unit/handler/parsers/test_output.py
+++ b/tests/unit/handler/parsers/test_output.py
@@ -79,5 +79,5 @@ class TestOutputParser(TestCase):
         failed = list(self.parser.parse_failed("php#phpunit", output))
         self.assertEqual(
             failed,
-            [ParseResult(name="test_fake", namespaces=[])],
+            [ParseResult(name="test_fake", namespaces=['Tests', 'FakeTest'])],
         )

--- a/tests/unit/handler/parsers/test_output.py
+++ b/tests/unit/handler/parsers/test_output.py
@@ -73,3 +73,13 @@ class TestOutputParser(TestCase):
                 ParseResult(name="TestAAAB", namespaces=[]),
             ],
         )
+    def test_parse_phpunit(self):
+        output = get_output("phpunit")
+        failed = list(self.parser.parse_failed("php#phpunit", output))
+        self.assertEqual(
+            failed,
+            [
+                ParseResult(name="test_fake", namespaces=["Tests\\FakeTest"])
+            ]
+        )
+     

--- a/tests/unit/handler/parsers/test_output.py
+++ b/tests/unit/handler/parsers/test_output.py
@@ -80,6 +80,6 @@ class TestOutputParser(TestCase):
             failed,
             [
                 ParseResult(name="test_fake", namespaces=["Tests\\FakeTest"])
-            ]
+            ],
         )
      

--- a/tests/unit/handler/parsers/test_output.py
+++ b/tests/unit/handler/parsers/test_output.py
@@ -79,5 +79,5 @@ class TestOutputParser(TestCase):
         failed = list(self.parser.parse_failed("php#phpunit", output))
         self.assertEqual(
             failed,
-            [ParseResult(name="test_fake", namespaces=["Tests\\FakeTest"])],
+            [ParseResult(name="test_fake", namespaces=[])],
         )

--- a/tests/unit/handler/parsers/test_output.py
+++ b/tests/unit/handler/parsers/test_output.py
@@ -73,13 +73,11 @@ class TestOutputParser(TestCase):
                 ParseResult(name="TestAAAB", namespaces=[]),
             ],
         )
+
     def test_parse_phpunit(self):
         output = get_output("phpunit")
         failed = list(self.parser.parse_failed("php#phpunit", output))
         self.assertEqual(
             failed,
-            [
-                ParseResult(name="test_fake", namespaces=["Tests\\FakeTest"])
-            ],
+            [ParseResult(name="test_fake", namespaces=["Tests\\FakeTest"])],
         )
-     


### PR DESCRIPTION
As mentioned in https://github.com/rcarriga/vim-ultest/issues/94 there is no parser for phpunit. This PR adds one.

My python is quite rusty. I've found out most of the stuff that needed to be done by looking around in the code. Only one thing that's unclear to me is that the namespaces array of the `ParseResult` is empty, while i've added a capturing group for it in the regex. I might have overlooked something. @rcarriga can you help out with this?

