### PR TITLE
fix issues in vim

### DIFF
--- a/plugin/ultest.vim
+++ b/plugin/ultest.vim
@@ -462,8 +462,8 @@ augroup END
 if !has("nvim")
   augroup UltestDummyCommand
     au!
-    au User UltestPositionsUpdate let <SID>dummy = 1
-    au User UltestOutputOpen let <SID>dummy = 1
+    au User UltestPositionsUpdate let s:dummy = 1
+    au User UltestOutputOpen let s:dummy = 1
   augroup END
 endif
 


### PR DESCRIPTION
previously the bindings / auto commands for error output would say

`Undefined variable <SID>dummy`

Minor fix for that.  Cool plugin!