### PR TITLE
Fixes issue introduced with 616bbca2e5d0a97edadb441df56bc21598e59a1a

### DIFF
--- a/plugin/ultest.vim
+++ b/plugin/ultest.vim
@@ -459,11 +459,14 @@ augroup UltestPositionUpdater
   endif
 augroup END
 
+function! s:dummy()
+endfunction
+
 if !has("nvim")
   augroup UltestDummyCommand
     au!
-    au User UltestPositionsUpdate let <SID>dummy = 1
-    au User UltestOutputOpen let <SID>dummy = 1
+    au User UltestPositionsUpdate call s:dummy()
+    au User UltestOutputOpen call s:dummy()
   augroup END
 endif
 


### PR DESCRIPTION
Whenever calling UltestOutput from vim, was getting an error saying s:dummy was not found. Figured it was introduced for compatibility with VIM8. 

Changed  to a noop method call that works without issues.