### PR TITLE
Fix error removing autocmds when the source is closed before the summary window

### DIFF
--- a/plugin/ultest.vim
+++ b/plugin/ultest.vim
@@ -462,8 +462,8 @@ augroup END
 if !has("nvim")
   augroup UltestDummyCommand
     au!
-    au User UltestPositionsUpdate let <SID>dummy = 1
-    au User UltestOutputOpen let <SID>dummy = 1
+    au User UltestPositionsUpdate let s:dummy = 1
+    au User UltestOutputOpen let sdummy = 1
   augroup END
 endif
 

--- a/plugin/ultest.vim
+++ b/plugin/ultest.vim
@@ -460,7 +460,7 @@ function! s:MonitorFile(file) abort
   let buffer = bufnr(a:file)
   call ultest#handler#update_positions(a:file)
   exec 'au BufWrite <buffer='.buffer.'> call ultest#handler#update_positions("'.a:file.'")'
-  exec 'au BufUnload <buffer='.buffer.'> au! * <buffer='.buffer'>'
+  exec 'au BufUnload <buffer='.buffer.'> au! * <buffer='.buffer.'>'
   if g:ultest_output_on_line
     exec 'au CursorHold <buffer='.buffer.'> call ultest#output#open(ultest#handler#get_nearest_test(line("."), expand("%:."), v:true))'
   endif

--- a/plugin/ultest.vim
+++ b/plugin/ultest.vim
@@ -462,8 +462,8 @@ augroup END
 if !has("nvim")
   augroup UltestDummyCommand
     au!
-    au User UltestPositionsUpdate let <SID>dummy = 1
-    au User UltestOutputOpen let <SID>dummy = 1
+    au User UltestPositionsUpdate let s:dummy = 1
+    au User UltestOutputOpen let s:dummy = 1
   augroup END
 endif
 


### PR DESCRIPTION
Just a missing . as far as I can tell.